### PR TITLE
feat: store expences saved in local db

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,19 +1,30 @@
-import React, { useState, useForm } from 'react';
+import React, { useState, useForm, useEffect } from 'react';
 import { StyleSheet, Text, TextInput, View, Button, Keyboard } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const Form = () => {
   const [amount, setAmount] = useState("");
   const [sum, setSum] = useState(0);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     Keyboard.dismiss()
     setSum(sum + Number(amount))
     setAmount("")
+    await AsyncStorage.setItem('expences', String(Number(sum) + Number(amount)));
+  }
+
+  useEffect(() => {
+    fetchValue()
+  })
+
+  const fetchValue = async () => {
+    const value = await AsyncStorage.getItem('expences');
+    setSum(value || 0)
   }
 
   return (
     <View>
-      <Text>Total Amount {sum}</Text>
+      <Text>Total Spent &#8377;{sum}</Text>
       <TextInput
         style={{ height: 40 }}
         placeholder="Enter Amount spent"
@@ -33,7 +44,6 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>Expence Tracking</Text>
-      <Text>Sum {global.totalSpent}</Text>
       <Form></Form>
     </View>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~3.1.3",
+        "@react-native-async-storage/async-storage": "1.21.0",
         "expo": "~50.0.8",
         "expo-status-bar": "~1.11.1",
         "expo-updates": "~0.24.11",
@@ -3673,6 +3674,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz",
+      "integrity": "sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -8606,6 +8618,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -9798,6 +9818,17 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "expo-updates": "~0.24.11",
     "react-native-web": "~0.19.6",
     "react-dom": "18.2.0",
-    "@expo/metro-runtime": "~3.1.3"
+    "@expo/metro-runtime": "~3.1.3",
+    "@react-native-async-storage/async-storage": "1.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
# Description

This PR allows for the expenses submitted to be persisted into mobile local storage. When the app opens, total expenses are fetched from DB and shown on the screen. 

# Testing 

https://github.com/whoAbhishekSah/ExpenceTracker/assets/17237043/7a8ce25c-57a5-4f0b-9033-c1643d6ca8dc

